### PR TITLE
zero cart_acceleration

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -225,7 +225,7 @@ function cart:on_step(dtime)
 		if math.abs(self.velocity.x) < 0.1 and  math.abs(self.velocity.z) < 0.1 then
 			-- Start the cart if powered from mesecons
 			local a = tonumber(minetest.env:get_meta(pos):get_string("cart_acceleration"))
-			if a then
+			if a and a ~= 0 then
 				for _,y in ipairs({0,-1,1}) do
 					for _,z in ipairs({1,-1}) do
 						if cart_func.v3:equal(self:get_rail_direction(self.object:getpos(), {x=0, y=y, z=z}), {x=0, y=y, z=z}) then


### PR DESCRIPTION
On regular rail, a pushed cart will slow down and stop, then move back slightly. On unpowered rail, (with `minetest.env:get_meta(pos):set_string("cart_acceleration", "0"`) the cart will slow down, and go forward and back in a manner that it seems the forward and back motions are fighting with each other.
This is one way of making the cart come to a full stop on rail that has zero acceleration set, the same as it stops on rail that has no acceleration set.
