### PR TITLE
Added default rail craft

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -10,6 +10,11 @@ License of media (textures, sounds and models):
 -----------------------------------------------
 CC-0
 
+Authors of lua:
+---------------
+bas080
+  Crafts using default:rail
+
 Authors of media files:
 -----------------------
 kddekadenz:

--- a/init.lua
+++ b/init.lua
@@ -575,3 +575,35 @@ minetest.register_craft({
 		{"default:steel_ingot", "default:coal_lump", "default:steel_ingot"},
 	}
 })
+
+minetest.register_craft({
+	output = "carts:powerrail 2",
+	recipe = {
+		{"default:mese_crystal_fragment"},
+		{"default:rail"},
+	}
+})
+
+minetest.register_craft({
+	output = "carts:powerrail 2",
+	recipe = {
+		{"default:rail"},
+		{"default:mese_crystal_fragment"},
+	}
+})
+
+minetest.register_craft({
+	output = "carts:brakerail 2",
+	recipe = {
+		{"default:coal_lump"},
+		{"default:rail"},
+	}
+})
+
+minetest.register_craft({
+	output = "carts:brakerail 2",
+	recipe = {
+		{"default:rail"},
+		{"default:coal_lump"},
+	}
+})


### PR DESCRIPTION
Now when you have default rail you can craft powerrail and brakerail using the default:rail.
